### PR TITLE
Update to jdk17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk17

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kafka logback appender [![](https://jitpack.io/v/Sberned/kafka-logback.svg)](https://jitpack.io/#Sberned/kafka-logback) ![](https://travis-ci.org/Sberned/kafka-logback.svg?branch=master) ![](https://maven-badges.herokuapp.com/maven-central/ru.sberned/kafka-logback/badge.svg)
 
-This is a logback appender for Kafka (0.10.1.0 kafka-client used)
+This is a logback appender for Kafka (3.7.0 kafka-client used)
 This appender expects topic, bootstrapServers, valueSerializer and layout as mandatory.
 You could also supply additional kafka customProps in `<customProps>` tag in the following manner
 `<customProps>key1|value1,key2|value2</customProps>`

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
     <name>kafka-logback</name>
     <description>Configurable kafka appender for logback</description>
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -19,7 +18,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.1</version>
+            <version>1.5.5</version>
         </dependency>
 
         <dependency>
@@ -37,40 +36,40 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr1</version>
+            <version>2.17.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.10.1.0</version>
+            <version>3.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.12</version>
+            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.6.1</version>
+            <version>3.25.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.26</version>
+            <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -79,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -88,7 +87,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -101,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -148,7 +147,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -159,7 +158,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.3</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/ru/sberned/kafkalogback/CustomJsonLayout.java
+++ b/src/main/java/ru/sberned/kafkalogback/CustomJsonLayout.java
@@ -2,7 +2,7 @@ package ru.sberned.kafkalogback;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.contrib.json.classic.JsonLayout;
-import ch.qos.logback.core.util.ContextUtil;
+import ch.qos.logback.core.util.NetworkAddressUtil;
 import lombok.Setter;
 
 import java.net.SocketException;
@@ -60,7 +60,7 @@ public class CustomJsonLayout extends JsonLayout {
 
     private String getHostName() {
         try {
-            return ContextUtil.getLocalHostName();
+            return NetworkAddressUtil.getLocalHostName();
         } catch (UnknownHostException|SocketException e) {
             return "undefined";
         }

--- a/src/test/java/ru/sberned/kafkalogback/CustomJsonLayoutTest.java
+++ b/src/test/java/ru/sberned/kafkalogback/CustomJsonLayoutTest.java
@@ -2,14 +2,14 @@ package ru.sberned.kafkalogback;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static ru.sberned.kafkalogback.CustomJsonLayout.*;
 
 /**
@@ -34,7 +34,7 @@ public class CustomJsonLayoutTest {
         Map<String, Object> result = new HashMap<>();
         layout.addCustomDataToJsonMap(result, event());
 
-        assertTrue(result.size() == 0);
+        assertEquals(0, result.size());
     }
 
     @Test

--- a/src/test/java/ru/sberned/kafkalogback/KafkaAppenderTest.java
+++ b/src/test/java/ru/sberned/kafkalogback/KafkaAppenderTest.java
@@ -7,7 +7,7 @@ import ch.qos.logback.core.Layout;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Properties;
@@ -15,6 +15,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchNullPointerException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,28 +52,28 @@ public class KafkaAppenderTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testLayoutIsMissing() {
         appender = new TestKafkaAppender("servers", "topic", "serializer", null);
-        appender.start();
+        catchNullPointerException(() -> appender.start());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testTopicIsMissing() {
         appender = new TestKafkaAppender("servers", null, "serializer", new JsonLayout());
-        appender.start();
+        catchNullPointerException(() -> appender.start());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSerializerIsMissing() {
         appender = new TestKafkaAppender("servers", "topic", null, new JsonLayout());
-        appender.start();
+        catchNullPointerException(() -> appender.start());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testBootstrapServersAreMissing() {
         appender = new TestKafkaAppender(null, "topic", "serializer", new JsonLayout());
-        appender.start();
+        catchNullPointerException(() -> appender.start());
     }
 
     @Test


### PR DESCRIPTION
A lot of dependencies were updated.
The most important update is update of logback-classic. `ContextUtil.getLocalHostName()` method was deleted and that's why `layout` is always `null` during logback initialization.